### PR TITLE
Add zone prefab settings and simplify generator

### DIFF
--- a/Assets/EXOFORM/Scripts/Map/DecorationPlacer.cs
+++ b/Assets/EXOFORM/Scripts/Map/DecorationPlacer.cs
@@ -10,13 +10,15 @@ namespace Exoform.Scripts.Map
     public class DecorationPlacer
     {
         private CityGrid cityGrid;
+        private ExoformZoneSystem zoneSystem;
         private List<PrefabSettings> decorationPrefabs;
         private MonoBehaviour coroutineRunner;
         private Dictionary<PrefabSettings, int> spawnedCounts;
 
-        public DecorationPlacer(CityGrid grid, List<GameObject> prefabs, MonoBehaviour runner)
+        public DecorationPlacer(CityGrid grid, ExoformZoneSystem zones, List<GameObject> prefabs, MonoBehaviour runner)
         {
             cityGrid = grid;
+            zoneSystem = zones;
             coroutineRunner = runner;
             spawnedCounts = new Dictionary<PrefabSettings, int>();
             LoadDecorationPrefabs(prefabs);
@@ -166,6 +168,14 @@ namespace Exoform.Scripts.Map
             // Базовая проверка
             if (!cityGrid.IsValidPosition(position))
                 return false;
+
+            if (zoneSystem != null)
+            {
+                var zone = zoneSystem.GetZoneAt(position);
+                if (zone.HasValue && settings.allowedZones.Count > 0 &&
+                    !settings.allowedZones.Contains(zone.Value.zoneType))
+                    return false;
+            }
 
             // Проверка занятости
             if (cityGrid.IsCellOccupiedByBuilding(position))

--- a/Assets/EXOFORM/Scripts/Map/ObjectPlacer.cs
+++ b/Assets/EXOFORM/Scripts/Map/ObjectPlacer.cs
@@ -11,13 +11,15 @@ namespace Exoform.Scripts.Map
     public class ObjectPlacer
     {
         private CityGrid cityGrid;
+        private ExoformZoneSystem zoneSystem;
         private List<PrefabSettings> prefabSettings;
         private Dictionary<PrefabSettings, int> spawnedCounts;
         private MonoBehaviour coroutineRunner;
 
-        public ObjectPlacer(CityGrid grid, List<GameObject> prefabs, MonoBehaviour runner)
+        public ObjectPlacer(CityGrid grid, ExoformZoneSystem zones, List<GameObject> prefabs, MonoBehaviour runner)
         {
             cityGrid = grid;
+            zoneSystem = zones;
             coroutineRunner = runner;
             spawnedCounts = new Dictionary<PrefabSettings, int>();
             LoadPrefabSettings(prefabs);
@@ -277,11 +279,18 @@ namespace Exoform.Scripts.Map
                 for (int y = 0; y <= cityGrid.Height - settings.gridSize.y; y++)
                 {
                     Vector2Int pos = new Vector2Int(x, y);
-                    if (settings.CanPlaceAtWithBuildingCheck(pos, cityGrid.Grid, cityGrid.Width, cityGrid.Height, 
+                    if (settings.CanPlaceAtWithBuildingCheck(pos, cityGrid.Grid, cityGrid.Width, cityGrid.Height,
                         cityGrid.IsCellOccupiedByBuilding))
                     {
                         if (settings.minDistanceFromRoad == 0 || HasRoadNearby(pos, settings.minDistanceFromRoad))
                         {
+                            if (zoneSystem != null)
+                            {
+                                var zone = zoneSystem.GetZoneAt(pos);
+                                if (zone.HasValue && settings.allowedZones.Count > 0 &&
+                                    !settings.allowedZones.Contains(zone.Value.zoneType))
+                                    continue;
+                            }
                             positions.Add(pos);
                         }
                     }

--- a/Assets/EXOFORM/Scripts/Map/PrefabConfiguration.cs
+++ b/Assets/EXOFORM/Scripts/Map/PrefabConfiguration.cs
@@ -30,6 +30,14 @@ namespace Exoform.Scripts.Map
         [Tooltip("Префабы ящиков с лутом")]
         public List<GameObject> lootPrefabs = new List<GameObject>();
 
+        [Header("🦠 Порча")]
+        [Tooltip("Префабы статичных элементов Порчи")]
+        public List<GameObject> corruptionPrefabs = new List<GameObject>();
+
+        [Header("🔧 Техника для восстановления")]
+        [Tooltip("Префабы техники, появляющейся в технических зонах")]
+        public List<GameObject> techSalvagePrefabs = new List<GameObject>();
+
         [Header("🎨 Декорации")]
         [Tooltip("Декоративные объекты")]
         public List<GameObject> decorationPrefabs = new List<GameObject>();
@@ -46,6 +54,8 @@ namespace Exoform.Scripts.Map
             allPrefabs.AddRange(resourcePrefabs.Where(p => p != null));
             allPrefabs.AddRange(roadObjectPrefabs.Where(p => p != null));
             allPrefabs.AddRange(lootPrefabs.Where(p => p != null));
+            allPrefabs.AddRange(corruptionPrefabs.Where(p => p != null));
+            allPrefabs.AddRange(techSalvagePrefabs.Where(p => p != null));
             allPrefabs.AddRange(decorationPrefabs.Where(p => p != null));
 
             return allPrefabs;
@@ -58,12 +68,14 @@ namespace Exoform.Scripts.Map
         {
             return category switch
             {
-                PrefabCategory.Buildings => buildingPrefabs.Where(p => p != null).ToList(),
-                PrefabCategory.Vegetation => vegetationPrefabs.Where(p => p != null).ToList(),
-                PrefabCategory.Resources => resourcePrefabs.Where(p => p != null).ToList(),
-                PrefabCategory.RoadObjects => roadObjectPrefabs.Where(p => p != null).ToList(),
-                PrefabCategory.Loot => lootPrefabs.Where(p => p != null).ToList(),
-                PrefabCategory.Decorations => decorationPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Buildings    => buildingPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Vegetation   => vegetationPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Resources    => resourcePrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.RoadObjects  => roadObjectPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Loot         => lootPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Corruption   => corruptionPrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.TechSalvage  => techSalvagePrefabs.Where(p => p != null).ToList(),
+                PrefabCategory.Decorations  => decorationPrefabs.Where(p => p != null).ToList(),
                 _ => new List<GameObject>()
             };
         }
@@ -143,9 +155,15 @@ namespace Exoform.Scripts.Map
                 TileType.BiomassResource or TileType.MetalResource => PrefabCategory.Resources,
                 
                 TileType.AbandonedVehicle or TileType.Barricade or TileType.WreckageDebris => PrefabCategory.RoadObjects,
-                
+
                 TileType.SupplyCache => PrefabCategory.Loot,
-                
+
+                TileType.TentacleGrowth or TileType.TumorNode or TileType.CorruptedGround or
+                TileType.SporeEmitter or TileType.BiologicalMass => PrefabCategory.Corruption,
+
+                TileType.DamagedGenerator or TileType.BrokenRobot or TileType.CorruptedTerminal or
+                TileType.TechSalvageResource => PrefabCategory.TechSalvage,
+
                 TileType.Decoration => PrefabCategory.Decorations,
                 
                 _ => PrefabCategory.Buildings
@@ -159,8 +177,10 @@ namespace Exoform.Scripts.Map
             if (resourcePrefabs.Contains(prefab)) return PrefabCategory.Resources;
             if (roadObjectPrefabs.Contains(prefab)) return PrefabCategory.RoadObjects;
             if (lootPrefabs.Contains(prefab)) return PrefabCategory.Loot;
+            if (corruptionPrefabs.Contains(prefab)) return PrefabCategory.Corruption;
+            if (techSalvagePrefabs.Contains(prefab)) return PrefabCategory.TechSalvage;
             if (decorationPrefabs.Contains(prefab)) return PrefabCategory.Decorations;
-            
+
             return PrefabCategory.Buildings; // по умолчанию
         }
 
@@ -175,6 +195,8 @@ namespace Exoform.Scripts.Map
             stats += $"⛏️ Ресурсов: {resourcePrefabs.Count(p => p != null)}\n";
             stats += $"🚗 Дорожных объектов: {roadObjectPrefabs.Count(p => p != null)}\n";
             stats += $"📦 Лута: {lootPrefabs.Count(p => p != null)}\n";
+            stats += $"🦠 Порчи: {corruptionPrefabs.Count(p => p != null)}\n";
+            stats += $"🔧 Техники: {techSalvagePrefabs.Count(p => p != null)}\n";
             stats += $"🎨 Декораций: {decorationPrefabs.Count(p => p != null)}\n";
             stats += $"📝 Всего: {GetAllPrefabs().Count}\n";
             
@@ -216,6 +238,12 @@ namespace Exoform.Scripts.Map
                         case PrefabCategory.Loot:
                             lootPrefabs.Add(prefab);
                             break;
+                        case PrefabCategory.Corruption:
+                            corruptionPrefabs.Add(prefab);
+                            break;
+                        case PrefabCategory.TechSalvage:
+                            techSalvagePrefabs.Add(prefab);
+                            break;
                         case PrefabCategory.Decorations:
                             decorationPrefabs.Add(prefab);
                             break;
@@ -232,6 +260,8 @@ namespace Exoform.Scripts.Map
         Resources,
         RoadObjects,
         Loot,
+        Corruption,
+        TechSalvage,
         Decorations
     }
 

--- a/Assets/EXOFORM/Scripts/Map/PrefabSettings.cs
+++ b/Assets/EXOFORM/Scripts/Map/PrefabSettings.cs
@@ -56,9 +56,19 @@ namespace Exoform.Scripts.Map
         
         [Tooltip("Список разрешенных углов поворота (0, 90, 180, 270)")]
         public List<float> allowedRotations = new List<float> { 0f, 90f, 180f, 270f };
-        
+
         [Tooltip("Случайный поворот если дорога не найдена")]
         public bool randomRotationIfNoRoad = false;
+
+        [Header("Zone Restrictions")]
+        [Tooltip("Зоны, в которых может появляться данный префаб")]
+        public List<TileType> allowedZones = new List<TileType>
+        {
+            TileType.StandardZone,
+            TileType.TechnicalZone,
+            TileType.ArtifactZone,
+            TileType.CorruptedTrap
+        };
 
         // ====== ВЫЧИСЛЯЕМЫЕ СВОЙСТВА ======
         

--- a/Assets/EXOFORM/Scripts/Map/RoadObjectsPlacer.cs
+++ b/Assets/EXOFORM/Scripts/Map/RoadObjectsPlacer.cs
@@ -10,13 +10,15 @@ namespace Exoform.Scripts.Map
     public class RoadObjectsPlacer
     {
         private CityGrid cityGrid;
+        private ExoformZoneSystem zoneSystem;
         private List<PrefabSettings> roadObjectPrefabs;
         private MonoBehaviour coroutineRunner;
         private Dictionary<PrefabSettings, int> spawnedCounts;
 
-        public RoadObjectsPlacer(CityGrid grid, List<GameObject> prefabs, MonoBehaviour runner)
+        public RoadObjectsPlacer(CityGrid grid, ExoformZoneSystem zones, List<GameObject> prefabs, MonoBehaviour runner)
         {
             cityGrid = grid;
+            zoneSystem = zones;
             coroutineRunner = runner;
             spawnedCounts = new Dictionary<PrefabSettings, int>();
             LoadRoadObjectPrefabs(prefabs);
@@ -146,6 +148,14 @@ namespace Exoform.Scripts.Map
             // Проверяем, что это действительно дорога
             if (cityGrid.Grid[position.x][position.y] != TileType.PathwayStraight)
                 return false;
+
+            if (zoneSystem != null)
+            {
+                var zone = zoneSystem.GetZoneAt(position);
+                if (zone.HasValue && settings.allowedZones.Count > 0 &&
+                    !settings.allowedZones.Contains(zone.Value.zoneType))
+                    return false;
+            }
 
             // Проверяем, не занята ли позиция другим объектом
             if (cityGrid.IsCellOccupiedByBuilding(position))

--- a/Assets/EXOFORM/Scripts/Map/TechSalvagePlacer.cs
+++ b/Assets/EXOFORM/Scripts/Map/TechSalvagePlacer.cs
@@ -11,13 +11,15 @@ namespace Exoform.Scripts.Map
     public class TechSalvagePlacer
     {
         private CityGrid cityGrid;
+        private ExoformZoneSystem zoneSystem;
         private List<PrefabSettings> techSalvagePrefabs;
         private MonoBehaviour coroutineRunner;
         private Dictionary<PrefabSettings, int> spawnedCounts;
 
-        public TechSalvagePlacer(CityGrid grid, List<GameObject> prefabs, MonoBehaviour runner)
+        public TechSalvagePlacer(CityGrid grid, ExoformZoneSystem zones, List<GameObject> prefabs, MonoBehaviour runner)
         {
             cityGrid = grid;
+            zoneSystem = zones;
             coroutineRunner = runner;
             spawnedCounts = new Dictionary<PrefabSettings, int>();
             LoadTechSalvagePrefabs(prefabs);

--- a/Assets/EXOFORM/Scripts/Map/VegetationPlacer.cs
+++ b/Assets/EXOFORM/Scripts/Map/VegetationPlacer.cs
@@ -10,12 +10,14 @@ namespace Exoform.Scripts.Map
     public class VegetationPlacer
     {
         private CityGrid cityGrid;
+        private ExoformZoneSystem zoneSystem;
         private List<PrefabSettings> vegetationPrefabs;
         private MonoBehaviour coroutineRunner;
 
-        public VegetationPlacer(CityGrid grid, List<GameObject> prefabs, MonoBehaviour runner)
+        public VegetationPlacer(CityGrid grid, ExoformZoneSystem zones, List<GameObject> prefabs, MonoBehaviour runner)
         {
             cityGrid = grid;
+            zoneSystem = zones;
             coroutineRunner = runner;
             LoadVegetationPrefabs(prefabs);
         }
@@ -222,6 +224,13 @@ namespace Exoform.Scripts.Map
                     Vector2Int pos = new Vector2Int(x, y);
                     if (CanPlaceVegetationAt(pos, settings))
                     {
+                        if (zoneSystem != null)
+                        {
+                            var zone = zoneSystem.GetZoneAt(pos);
+                            if (zone.HasValue && settings.allowedZones.Count > 0 &&
+                                !settings.allowedZones.Contains(zone.Value.zoneType))
+                                continue;
+                        }
                         positions.Add(pos);
                     }
                 }


### PR DESCRIPTION
## Summary
- make prefab configuration support corruption and tech salvage categories
- add allowed zone list to `PrefabSettings`
- factor coroutines out of `ExoformMapGenerator`
- pass zone system to placers and apply zone checks during placement

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_686a980cc7788326bd6b4e446960ac19