### PR TITLE
Remove obsolete map generator options

### DIFF
--- a/Assets/EXOFORM/Scenes/WorldGenScebe.unity
+++ b/Assets/EXOFORM/Scenes/WorldGenScebe.unity
@@ -334,7 +334,6 @@ MonoBehaviour:
   createCorruptionClusters: 1
   techSalvageDensity: 0.05
   pathwayLength: 30
-  useImprovedPathwayGenerator: 1
   advancedPathwaySettings:
     branchProbability: 0.3
     minSegmentLength: 10
@@ -349,7 +348,6 @@ MonoBehaviour:
   supplyCacheClusterSize: 3
   animationSpeed: 0.5
   useBatchedVisualUpdates: 1
-  pathwaysOverGrass: 1
   grassPrefabs:
   - {fileID: 8350565405820835728, guid: a3f672e3be2f5c34db6509158f75506b, type: 3}
   - {fileID: 8350565405820835728, guid: 4680cf934f0edda4e80790168fb7d926, type: 3}

--- a/Assets/EXOFORM/Scripts/Map/ExoformMapGenerator.cs
+++ b/Assets/EXOFORM/Scripts/Map/ExoformMapGenerator.cs
@@ -73,9 +73,6 @@ namespace Exoform.Scripts.Map
         [Range(3, 30)] [Tooltip("Длина сегмента пути")]
         public int pathwayLength = 15;
         
-        [Tooltip("Использовать улучшенный генератор путей")]
-        public bool useImprovedPathwayGenerator = true;
-        
         [Tooltip("Настройки для улучшенного генератора путей")]
         public ImprovedRoadGenerator.RoadSettings advancedPathwaySettings = new ImprovedRoadGenerator.RoadSettings();
 
@@ -106,8 +103,6 @@ namespace Exoform.Scripts.Map
         [Tooltip("Пакетное обновление визуала (улучшает производительность)")]
         public bool useBatchedVisualUpdates = true;
         
-        [Tooltip("Дороги размещаются поверх травы (не удаляют траву)")]
-        public bool pathwaysOverGrass = true;
 
         [Header("🎯 Base Prefabs")]
         [Tooltip("Массив префабов травы (выбирается случайный)")]
@@ -160,7 +155,6 @@ namespace Exoform.Scripts.Map
 
         // Компоненты системы
         private CityGrid cityGrid;
-        private RoadGenerator roadGenerator;
         private ImprovedRoadGenerator improvedRoadGenerator;
         private ObjectPlacer objectPlacer;
         private VegetationPlacer vegetationPlacer;
@@ -273,21 +267,14 @@ namespace Exoform.Scripts.Map
             InitializeExoformSystems(allPrefabs);
 
             // Инициализация спавнера тайлов с поддержкой массивов префабов
-            tileSpawner ??= new TileSpawner(cityGrid, transform, pathwaysOverGrass);
+            tileSpawner ??= new TileSpawner(cityGrid, transform);
 
             LogDebug("Все компоненты инициализированы");
         }
 
         private void InitializePathwayGenerators()
         {
-            if (useImprovedPathwayGenerator)
-            {
-                improvedRoadGenerator ??= new ImprovedRoadGenerator(cityGrid, advancedPathwaySettings, pathwaysOverGrass);
-            }
-            else
-            {
-                roadGenerator ??= new RoadGenerator(cityGrid, pathwaysOverGrass);
-            }
+            improvedRoadGenerator ??= new ImprovedRoadGenerator(cityGrid, advancedPathwaySettings);
         }
 
         private void InitializePlacers(List<GameObject> allPrefabs)
@@ -496,14 +483,7 @@ namespace Exoform.Scripts.Map
 
         private IEnumerator GeneratePathways()
         {
-            if (useImprovedPathwayGenerator)
-            {
-                yield return StartCoroutine(improvedRoadGenerator.GenerateRoads(pathwayDensity, pathwayLength, animationSpeed));
-            }
-            else
-            {
-                yield return StartCoroutine(roadGenerator.GenerateRoads(pathwayDensity, pathwayLength, animationSpeed));
-            }
+            yield return StartCoroutine(improvedRoadGenerator.GenerateRoads(pathwayDensity, pathwayLength, animationSpeed));
         }
 
         private IEnumerator PlaceStructures()
@@ -1068,97 +1048,5 @@ namespace Exoform.Scripts.Map
 
         #endregion
 
-        #region Legacy Support Properties
-
-        // Для обратной совместимости с существующими скриптами
-        public GameObject grassPrefab
-        {
-            get => grassPrefabs != null && grassPrefabs.Length > 0 ? grassPrefabs[0] : null;
-            set
-            {
-                if (grassPrefabs == null || grassPrefabs.Length == 0)
-                    grassPrefabs = new GameObject[1];
-                grassPrefabs[0] = value;
-            }
-        }
-        
-        public GameObject pathwayPrefab
-        {
-            get => pathwayPrefabs != null && pathwayPrefabs.Length > 0 ? pathwayPrefabs[0] : null;
-            set
-            {
-                if (pathwayPrefabs == null || pathwayPrefabs.Length == 0)
-                    pathwayPrefabs = new GameObject[1];
-                pathwayPrefabs[0] = value;
-            }
-        }
-        
-        public float roadDensity
-        {
-            get => pathwayDensity;
-            set => pathwayDensity = value;
-        }
-
-        public float buildingDensity
-        {
-            get => structureDensity;
-            set => structureDensity = value;
-        }
-
-        public float roadObjectDensity
-        {
-            get => pathwayObjectDensity;
-            set => pathwayObjectDensity = value;
-        }
-
-        public float lootDensity
-        {
-            get => supplyCacheDensity;
-            set => supplyCacheDensity = value;
-        }
-
-        public int roadLength
-        {
-            get => pathwayLength;
-            set => pathwayLength = value;
-        }
-
-        public bool useImprovedRoadGenerator
-        {
-            get => useImprovedPathwayGenerator;
-            set => useImprovedPathwayGenerator = value;
-        }
-
-        public ImprovedRoadGenerator.RoadSettings advancedRoadSettings
-        {
-            get => advancedPathwaySettings;
-            set => advancedPathwaySettings = value;
-        }
-
-        public int minLootCount
-        {
-            get => minSupplyCacheCount;
-            set => minSupplyCacheCount = value;
-        }
-
-        public int maxLootCount
-        {
-            get => maxSupplyCacheCount;
-            set => maxSupplyCacheCount = value;
-        }
-
-        public bool clusterLoot
-        {
-            get => clusterSupplyCache;
-            set => clusterSupplyCache = value;
-        }
-
-        public int lootClusterSize
-        {
-            get => supplyCacheClusterSize;
-            set => supplyCacheClusterSize = value;
-        }
-
-        #endregion
     }
 }

--- a/Assets/EXOFORM/Scripts/Map/ImprovedRoadGenerator.cs
+++ b/Assets/EXOFORM/Scripts/Map/ImprovedRoadGenerator.cs
@@ -10,7 +10,6 @@ namespace Exoform.Scripts.Map
     public class ImprovedRoadGenerator
     {
         private CityGrid cityGrid;
-        private bool pathwaysOverGrass;
         
         [System.Serializable]
         public class RoadSettings
@@ -30,11 +29,10 @@ namespace Exoform.Scripts.Map
         
         private RoadSettings settings;
 
-        public ImprovedRoadGenerator(CityGrid grid, RoadSettings roadSettings = null, bool pathwaysOverGrass = false)
+        public ImprovedRoadGenerator(CityGrid grid, RoadSettings roadSettings = null)
         {
             cityGrid = grid;
             settings = roadSettings ?? new RoadSettings();
-            this.pathwaysOverGrass = pathwaysOverGrass;
         }
 
         public IEnumerator GenerateRoads(float density, int roadLength, float animationSpeed)
@@ -48,11 +46,6 @@ namespace Exoform.Scripts.Map
             
             Debug.Log($"🛤️ Генерация улучшенных дорог (цель: {targetRoadCells} клеток, длина сегментов: {settings.minSegmentLength}-{settings.maxSegmentLength})");
             
-            if (pathwaysOverGrass)
-            {
-                Debug.Log("  📌 Режим: дороги размещаются поверх травы");
-            }
-
             // Создаем основные магистрали
             yield return CreateMainRoads(animationSpeed);
             

--- a/Assets/EXOFORM/Scripts/Map/RoadGenerator.cs
+++ b/Assets/EXOFORM/Scripts/Map/RoadGenerator.cs
@@ -10,12 +10,10 @@ namespace Exoform.Scripts.Map
     public class RoadGenerator
     {
         private CityGrid cityGrid;
-        private bool pathwaysOverGrass;
 
-        public RoadGenerator(CityGrid grid, bool pathwaysOverGrass = false)
+        public RoadGenerator(CityGrid grid)
         {
             cityGrid = grid;
-            this.pathwaysOverGrass = pathwaysOverGrass;
         }
 
         public IEnumerator GenerateRoads(float density, int roadLength, float animationSpeed)
@@ -25,11 +23,6 @@ namespace Exoform.Scripts.Map
             int roadSegments = Mathf.Max(1, targetRoadCells / roadLength);
 
             Debug.Log($"🛤️ Планируем создать {roadSegments} сегментов (целевое количество клеток: {targetRoadCells}, {density * 100:F1}% карты)");
-            
-            if (pathwaysOverGrass)
-            {
-                Debug.Log("  📌 Режим: дороги размещаются поверх травы");
-            }
 
             // Подсчитываем дороги до генерации
             int roadsBefore = CountRoadCells();
@@ -72,19 +65,7 @@ namespace Exoform.Scripts.Map
 
         Vector2Int GetRandomStartPosition()
         {
-            // Если дороги поверх травы, можем начинать с любой позиции
-            if (pathwaysOverGrass)
-            {
-                return new Vector2Int(
-                    Random.Range(0, cityGrid.Width),
-                    Random.Range(0, cityGrid.Height)
-                );
-            }
-            else
-            {
-                // Старый режим - ищем только траву
-                return GetRandomGrassPosition();
-            }
+            return GetRandomGrassPosition();
         }
 
         Vector2Int GetRandomGrassPosition()

--- a/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
+++ b/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
@@ -12,13 +12,11 @@ namespace Exoform.Scripts.Map
         private CityGrid cityGrid;
         private Transform parent;
         private Dictionary<string, int> spawnedPrefabCounts;
-        private bool pathwaysOverGrass; // Дороги поверх травы
 
-        public TileSpawner(CityGrid grid, Transform parentTransform, bool pathwaysOverGrass = false)
+        public TileSpawner(CityGrid grid, Transform parentTransform)
         {
             cityGrid = grid;
             parent = parentTransform;
-            this.pathwaysOverGrass = pathwaysOverGrass;
             spawnedPrefabCounts = new Dictionary<string, int>();
         }
 
@@ -28,13 +26,12 @@ namespace Exoform.Scripts.Map
             Debug.Log("  🎯 Создание базовых тайлов...");
             spawnedPrefabCounts.Clear();
 
-            // Сначала создаем все тайлы травы
+            // Создаем базовые тайлы (трава или дорога)
             for (int x = 0; x < cityGrid.Width; x++)
             {
                 for (int y = 0; y < cityGrid.Height; y++)
                 {
-                    // Создаем траву везде
-                    CreateGrassTileAt(x, y, grassPrefabs);
+                    CreateTileAt(x, y, grassPrefabs, pathwayPrefabs);
 
                     if ((x * cityGrid.Height + y) % 10 == 0)
                     {
@@ -43,26 +40,6 @@ namespace Exoform.Scripts.Map
                 }
             }
 
-            // Если дороги поверх травы, создаем их как отдельный слой
-            if (pathwaysOverGrass)
-            {
-                Debug.Log("  🛤️ Создание дорог поверх травы...");
-                for (int x = 0; x < cityGrid.Width; x++)
-                {
-                    for (int y = 0; y < cityGrid.Height; y++)
-                    {
-                        if (cityGrid.Grid[x][y] == TileType.PathwayStraight)
-                        {
-                            CreatePathwayOverGrass(x, y, pathwayPrefabs);
-                        }
-                    }
-
-                    if (x % 5 == 0)
-                    {
-                        yield return new WaitForSeconds(animationSpeed * 0.1f);
-                    }
-                }
-            }
 
             Debug.Log("  🏢 Создание зданий поверх базы...");
             CreateBuildingsLayer(prefabsWithSettings);
@@ -90,23 +67,8 @@ namespace Exoform.Scripts.Map
                         }
                     }
 
-                    // Создаем новые тайлы
-                    if (pathwaysOverGrass)
-                    {
-                        // Всегда создаем траву
-                        CreateGrassTileAt(x, y, grassPrefabs);
-                        
-                        // Дорогу создаем поверх если нужно
-                        if (cityGrid.Grid[x][y] == TileType.PathwayStraight)
-                        {
-                            CreatePathwayOverGrass(x, y, pathwayPrefabs);
-                        }
-                    }
-                    else
-                    {
-                        // Старый режим - либо трава, либо дорога
-                        CreateTileAt(x, y, grassPrefabs, pathwayPrefabs);
-                    }
+                    // Создаем новый тайл в соответствии с типом клетки
+                    CreateTileAt(x, y, grassPrefabs, pathwayPrefabs);
                 }
 
                 yield return new WaitForSeconds(animationSpeed * 0.1f);
@@ -159,25 +121,6 @@ namespace Exoform.Scripts.Map
             cityGrid.SpawnedTiles[x][y] = grassTile;
         }
 
-        void CreatePathwayOverGrass(int x, int y, GameObject[] pathwayPrefabs)
-        {
-            if (pathwayPrefabs == null || pathwayPrefabs.Length == 0) return;
-            
-            Vector3 position = cityGrid.GetWorldPosition(x, y);
-            // Поднимаем дорогу немного выше травы
-            position.y += 0.05f;
-            
-            // Выбираем случайный префаб дороги
-            GameObject pathwayPrefab = GetRandomPrefab(pathwayPrefabs);
-            if (pathwayPrefab == null) return;
-
-            GameObject pathway = Object.Instantiate(pathwayPrefab, position, Quaternion.Euler(0, Random.Range(0, 4) * 90, 0));
-            pathway.name = $"Pathway_{x}_{y}";
-            pathway.transform.SetParent(parent);
-            
-            // Не заменяем ссылку в SpawnedTiles - там остается трава
-            // Дорога существует как отдельный объект поверх
-        }
 
         void CreateTileAt(int x, int y, GameObject[] grassPrefabs, GameObject[] pathwayPrefabs)
         {


### PR DESCRIPTION
## Summary
- drop grass overlay and improved generator checkboxes
- default to improved road generator
- delete legacy support properties
- update scene to reflect new generator settings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686abb62ec6c832690b48c50da995982