### PR TITLE
Fix base cell retrieval in TileSpawner

### DIFF
--- a/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
+++ b/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
@@ -207,11 +207,12 @@ namespace Exoform.Scripts.Map
 
                 foreach (var buildingGroup in buildingGroups)
                 {
-                    Vector2Int baseCell = buildingGroup[0];
+                    Vector2Int baseCell = buildingGroup[0].Cell;
                     foreach (var cell in buildingGroup)
                     {
-                        if (cell.x < baseCell.x || (cell.x == baseCell.x && cell.y < baseCell.y))
-                            baseCell = cell;
+                        var cellPos = cell.Cell;
+                        if (cellPos.x < baseCell.x || (cellPos.x == baseCell.x && cellPos.y < baseCell.y))
+                            baseCell = cellPos;
                     }
 
                     if (processedBuildings.Contains(baseCell))


### PR DESCRIPTION
## Summary
- fix base cell selection in `CreateBuildingsLayer` to use `OccupiedCell.Cell`
- compare positions using `cellPos` without altering method parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac9506c94832687733ab82c0b59fa