### PR TITLE
Fix map regeneration cleanup

### DIFF
--- a/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
+++ b/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
@@ -87,8 +87,9 @@ namespace Exoform.Scripts.Map
             foreach (Transform child in parent)
             {
                     
-                if (child.name.StartsWith("Building_") || 
-                    child.name.StartsWith("Vegetation_") || 
+                if (child.name.StartsWith("Building_") ||
+                    child.name.StartsWith("Structure_") ||
+                    child.name.StartsWith("Vegetation_") ||
                     child.name.StartsWith("RoadObject_") ||
                     child.name.StartsWith("Loot_") ||
                     child.name.StartsWith("Pathway_"))


### PR DESCRIPTION
## Summary
- include `Structure_` in TileSpawner cleanup filters

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ad2d5e808832682643cebdecd7436