### PR TITLE
Fix cleanup for map object categories

### DIFF
--- a/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
+++ b/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
@@ -81,27 +81,26 @@ namespace Exoform.Scripts.Map
 
         void ClearExistingBuildings()
         {
-            // Удаляем все объекты кроме базовых тайлов и объединенной травы
+            // Удаляем все ранее созданные визуальные объекты на тайлах
             List<GameObject> toDestroy = new List<GameObject>();
-            
+
             foreach (Transform child in parent)
             {
-                    
-                if (child.name.StartsWith("Building_") || 
-                    child.name.StartsWith("Vegetation_") || 
+                if (child.name.StartsWith("Structure_") ||
+                    child.name.StartsWith("Vegetation_") ||
                     child.name.StartsWith("RoadObject_") ||
-                    child.name.StartsWith("Loot_") ||
-                    child.name.StartsWith("Pathway_"))
+                    child.name.StartsWith("SupplyCache_") ||
+                    child.name.StartsWith("Decoration_"))
                 {
                     toDestroy.Add(child.gameObject);
                 }
             }
-            
+
             foreach (var obj in toDestroy)
             {
                 Object.DestroyImmediate(obj);
             }
-            
+
             spawnedPrefabCounts.Clear();
         }
 
@@ -328,6 +327,7 @@ namespace Exoform.Scripts.Map
             if (IsVegetationType(type)) return "Vegetation";
             if (IsRoadObjectType(type)) return "RoadObject";
             if (type == TileType.SupplyCache) return "SupplyCache";
+            if (IsDecorationType(type)) return "Decoration";
             return "Structure";
         }
 

--- a/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
+++ b/Assets/EXOFORM/Scripts/Map/TileSpawner.cs
@@ -13,6 +13,16 @@ namespace Exoform.Scripts.Map
         private Transform parent;
         private Dictionary<string, int> spawnedPrefabCounts;
 
+        // Префиксы для удаляемых объектов. Соответствуют категориям из GetObjectCategory.
+        private static readonly string[] ObjectCategoryPrefixes =
+        {
+            "Structure_",
+            "Vegetation_",
+            "RoadObject_",
+            "SupplyCache_",
+            "Decoration_"
+        };
+
         public TileSpawner(CityGrid grid, Transform parentTransform)
         {
             cityGrid = grid;
@@ -86,13 +96,13 @@ namespace Exoform.Scripts.Map
 
             foreach (Transform child in parent)
             {
-                if (child.name.StartsWith("Structure_") ||
-                    child.name.StartsWith("Vegetation_") ||
-                    child.name.StartsWith("RoadObject_") ||
-                    child.name.StartsWith("SupplyCache_") ||
-                    child.name.StartsWith("Decoration_"))
+                foreach (var prefix in ObjectCategoryPrefixes)
                 {
-                    toDestroy.Add(child.gameObject);
+                    if (child.name.StartsWith(prefix))
+                    {
+                        toDestroy.Add(child.gameObject);
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- remove spawned objects for all categories in `TileSpawner`
- support decoration category name in `GetObjectCategory`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ad33740e883269a9c6d17dfbc1be3