### PR TITLE
Improve unit spawn architecture

### DIFF
--- a/Assets/EXOFORM/Scripts/Ecs/Systems/UnitLogicSystems/UnitVisualizationSystem.cs
+++ b/Assets/EXOFORM/Scripts/Ecs/Systems/UnitLogicSystems/UnitVisualizationSystem.cs
@@ -72,9 +72,10 @@ namespace Exoform.Scripts.Ecs.Systems.UnitLogicSystems
 
             if (visualController != null)
             {
-                // Назначаем уникальный ID
+                // Назначаем уникальный ID и связываем с Entity
                 int unitId = nextUnitId++;
                 visualController.unitId = unitId;
+                visualController.LinkEntity(entity);
 
                 // Добавляем UnitProxyComponent к Entity
                 EntityManager.AddComponentData(entity, new UnitProxyComponent

--- a/Assets/EXOFORM/Scripts/Hybrid/SpawnManager.cs
+++ b/Assets/EXOFORM/Scripts/Hybrid/SpawnManager.cs
@@ -3,6 +3,7 @@ using EXOFORM.Scripts.Ecs.Systems.Spawning;
 using Unity.Entities;
 using UnityEngine;
 
+using Exoform.Scripts.Ecs.Components.UnitLogicComponents;
 namespace Exoform.Scripts.Hybrid
 {
     /// <summary>
@@ -62,5 +63,21 @@ namespace Exoform.Scripts.Hybrid
             
             query.Dispose();
         }
+
+        /// <summary>
+        /// Спаун юнита в указанной позиции
+        /// </summary>
+        public static Entity SpawnUnit(Vector3 position, UnitType type, int teamId)
+        {
+            var spawner = Object.FindObjectOfType<UnitSpawner>();
+            if (spawner == null)
+            {
+                Debug.LogError("UnitSpawner not found in scene!");
+                return Entity.Null;
+            }
+
+            return spawner.SpawnUnitAtPosition(position, type, teamId);
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- use archetypes when creating entities in `UnitSpawner`
- expose `SpawnManager.SpawnUnit` helper
- link spawned entities with visuals directly
- simplify visual controller and ECS checks

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715860ed648326b7e5f628eedc5caf